### PR TITLE
Update comment style

### DIFF
--- a/shakespeare-mode.el
+++ b/shakespeare-mode.el
@@ -132,8 +132,8 @@
   (modify-syntax-entry ?\n "> b" shakespeare-lucius-mode-syntax-table)
   ;; Special chars that sometimes come at the beginning of words.
   (modify-syntax-entry ?. "'" shakespeare-lucius-mode-syntax-table)
-  (set (make-local-variable 'comment-start) "//")
-  (set (make-local-variable 'comment-end) "")
+  (set (make-local-variable 'comment-start) "/*")
+  (set (make-local-variable 'comment-end) "*/")
   ;; indentation
   (set (make-local-variable 'indent-line-function) 'shakespeare-lucius-indent-line))
 


### PR DESCRIPTION
`comment-region` defaults to using `// this style`, but I think `/* this style */` is the right one, especially in the presence of minifiers.

For example: 

```
h1 {
    color: #fff; // some comment
    font-size: 120%;
}
```

Firefox will ignore the above `font-size`.

(I'm not sure `// this style` is valid CSS either.  See https://www.w3.org/TR/css-syntax-3/#comment-diagram.)